### PR TITLE
Fix nginx start issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN rm /etc/nginx/sites-enabled/default
 COPY flask.conf /etc/nginx/sites-available/
 RUN ln -s /etc/nginx/sites-available/flask.conf /etc/nginx/sites-enabled/flask.conf
 COPY uwsgi.ini /var/www/app/
+RUN echo "daemon off;" >> /etc/nginx/nginx.conf
 
 
 RUN mkdir -p /var/log/supervisor


### PR DESCRIPTION
Because nginx is starting in daemon mode, supervisord continually tries to restart it despite it already running in the background.

I have added a line to the Dockerfile which will change the nginx.conf file to prevent it from running in daemon mode, which means supervisord will start it properly.

This solves issue #4 
